### PR TITLE
use uuid field to identify help_requests

### DIFF
--- a/app/controllers/help_requests_controller.rb
+++ b/app/controllers/help_requests_controller.rb
@@ -15,7 +15,7 @@ class HelpRequestsController < ApplicationController
 
   def update
     if @help_request.update(help_request_params_update)
-      redirect_to @help_request
+      redirect_to help_request_path(uuid: @help_request.uuid)
     else
       render :edit
     end
@@ -28,7 +28,7 @@ class HelpRequestsController < ApplicationController
       redirect_to :homepage
     else
       flash.alert = I18n.t("help_requests_edit.flash_delete_error")
-      redirect_to edit_help_request_path(id: @help_request.id)
+      redirect_to edit_help_request_path(uuid: @help_request.uuid)
     end
   end
 
@@ -37,9 +37,11 @@ class HelpRequestsController < ApplicationController
     @help_request.creator_uuid = SecureRandom.uuid
 
     if @help_request.valid? && @help_request.save
+      @help_request.reload
       set_creator_uuid_cookie(@help_request)
+
       flash.notice = I18n.t("help_requests_new.flash_created_success")
-      redirect_to @help_request
+      redirect_to help_request_path(uuid: @help_request.uuid)
     else
       flash.alert = I18n.t("help_requests_new.flash_creation_error")
       render :new
@@ -52,7 +54,7 @@ class HelpRequestsController < ApplicationController
   def confirm_security_number
     if @help_request.validate_security_number(security_number_params[:security_number])
       set_creator_uuid_cookie(@help_request)
-      redirect_to edit_help_request_path(id: @help_request.id)
+      redirect_to edit_help_request_path(uuid: @help_request.uuid)
     else
       flash.alert = I18n.t("help_requests_ask_security_number.flash_error")
       render :ask_security_number
@@ -62,12 +64,12 @@ class HelpRequestsController < ApplicationController
   private
 
   def load_help_request
-    @help_request = HelpRequest.find(params[:id])
+    @help_request = HelpRequest.find_by!(uuid: params[:uuid])
   end
 
   def verify_ownership
     unless @help_request.is_owner?(cookies[:creator_uuid])
-      redirect_to help_request_confirm_security_number_path(id: @help_request.id)
+      redirect_to help_request_confirm_security_number_path(uuid: @help_request.uuid)
     end
   end
 

--- a/app/javascript/packs/help-now-show.js
+++ b/app/javascript/packs/help-now-show.js
@@ -6,7 +6,7 @@ function infoWindowForRequest(request) {
     <h2 class="capitalize">${request.name}</h2>
     <strong>${request.address}</strong>
     <p class="white-spaces">${request.description}</p>
-    <a href="/help-requests/${request.id}">more info</a>
+    <a href="/help-requests/${request.uuid}">more info</a>
   </div>
   `
 }

--- a/app/models/help_request.rb
+++ b/app/models/help_request.rb
@@ -41,6 +41,7 @@ class HelpRequest < ApplicationRecord
   def as_json(options = {})
     {
       id: id,
+      uuid: uuid,
       name: name,
       description: description,
       address: address,

--- a/app/views/help_requests/edit.html.erb
+++ b/app/views/help_requests/edit.html.erb
@@ -6,13 +6,13 @@
 </style>
 
 <h1><%= t('help_requests_edit.title') %></h1>
-<%= form_with(model: @help_request, url: :edit_help_request, local: true) do |f| %>
+<%= form_with(model: @help_request, url: edit_help_request_path(uuid: @help_request.uuid), local: true) do |f| %>
   <%= render partial: 'form', locals: {f: f} %>
   <%= f.submit t('edit') %>
 <% end %>
 <hr>
 <h2><%= t('help_requests_edit.danger_zone') %></h2>
 <p><%= t('help_requests_edit.delete_description') %></p>
-<%= link_to t('delete'), edit_help_request_path(:id => @help_request.id), class: "btn btn-danger", method: :delete %>
+<%= link_to t('delete'), edit_help_request_path(:uuid => @help_request.uuid), class: "btn btn-danger", method: :delete %>
 
 <%= javascript_pack_tag 'help-requests-form' %>

--- a/app/views/help_requests/show.html.erb
+++ b/app/views/help_requests/show.html.erb
@@ -26,7 +26,7 @@
 <div id="google-map-container">
 </div>
 
-<%= link_to t("help_requests_show.edit"), edit_help_request_path(:id => @help_request.id) %>
+<%= link_to t("help_requests_show.edit"), edit_help_request_path(:uuid => @help_request.uuid) %>
 
 <input id="help-request-lat" type="hidden" value="<%= @help_request.address_lat %>">
 <input id="help-request-lon" type="hidden" value="<%= @help_request.address_lon %>">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,12 +5,12 @@ Rails.application.routes.draw do
 
   get     '/help-requests', to: 'help_requests#new', as: :new_help_request
   post    '/help-requests', to: 'help_requests#create'
-  get     '/help-requests/:id', to: 'help_requests#show', as: :help_request
-  get     '/help-requests/:id/edit', to: 'help_requests#edit', as: :edit_help_request
-  patch   '/help-requests/:id/edit', to: 'help_requests#update'
-  delete  '/help-requests/:id/edit', to: 'help_requests#delete'
-  get     '/help-requests/:id/confirm-security-number', to: 'help_requests#ask_security_number', as: :help_request_confirm_security_number
-  post    '/help-requests/:id/confirm-security-number', to: 'help_requests#confirm_security_number'
+  get     '/help-requests/:uuid', to: 'help_requests#show', as: :help_request
+  get     '/help-requests/:uuid/edit', to: 'help_requests#edit', as: :edit_help_request
+  patch   '/help-requests/:uuid/edit', to: 'help_requests#update'
+  delete  '/help-requests/:uuid/edit', to: 'help_requests#delete'
+  get     '/help-requests/:uuid/confirm-security-number', to: 'help_requests#ask_security_number', as: :help_request_confirm_security_number
+  post    '/help-requests/:uuid/confirm-security-number', to: 'help_requests#confirm_security_number'
 
   get '/help-now', to: 'help_now#show'
   get '/help-now/search', to: 'help_now#search'

--- a/db/migrate/20200331225728_add_uuid_to_help_request.rb
+++ b/db/migrate/20200331225728_add_uuid_to_help_request.rb
@@ -1,0 +1,7 @@
+class AddUuidToHelpRequest < ActiveRecord::Migration[6.0]
+  def change
+    enable_extension 'uuid-ossp'
+    add_column :help_requests, :uuid, :uuid, default: "uuid_generate_v4()", null: false
+    add_index :help_requests, :uuid
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,11 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_03_30_195524) do
+ActiveRecord::Schema.define(version: 2020_03_31_225728) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
   enable_extension "postgis"
+  enable_extension "uuid-ossp"
 
   create_table "help_requests", force: :cascade do |t|
     t.string "name"
@@ -29,8 +30,10 @@ ActiveRecord::Schema.define(version: 2020_03_30_195524) do
     t.string "security_number"
     t.string "creator_uuid"
     t.boolean "deleted", default: false
+    t.uuid "uuid", default: -> { "uuid_generate_v4()" }, null: false
     t.index ["address_lonlat"], name: "index_help_requests_on_address_lonlat", using: :gist
     t.index ["deleted"], name: "index_help_requests_on_deleted"
+    t.index ["uuid"], name: "index_help_requests_on_uuid"
   end
 
 end

--- a/test/controllers/help_requests_controller_test.rb
+++ b/test/controllers/help_requests_controller_test.rb
@@ -1,6 +1,10 @@
 require 'test_helper'
 
 class HelpRequestsControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    cookies[:locale] = 'en'
+  end
+
   test "when creating a new help request, the creator uuid is set in creator_uuid cookie" do
     assert_nil cookies[:creator_uuid]
     params = {
@@ -24,20 +28,20 @@ class HelpRequestsControllerTest < ActionDispatch::IntegrationTest
   test "redirect to confirm security_number page if creator_uuid does not match when trying to edit" do
     assert_nil cookies[:creator_uuid]
     help_request = help_requests(:monique_request)
-    get edit_help_request_path(id: help_request.id)
-    assert_redirected_to help_request_confirm_security_number_path(id: help_request.id)
+    get edit_help_request_path(uuid: help_request.uuid)
+    assert_redirected_to help_request_confirm_security_number_path(uuid: help_request.uuid)
   end
 
   test "#confirm_security_number with right security_number redirects to #edit and set creator_uuid cookie" do
     help_request = help_requests(:monique_request)
-    post help_request_confirm_security_number_path(id: help_request.id), params: {security_number: "123321"}
-    assert_redirected_to edit_help_request_path(id: help_request.id)
+    post help_request_confirm_security_number_path(uuid: help_request.uuid), params: {security_number: "123321"}
+    assert_redirected_to edit_help_request_path(uuid: help_request.uuid)
     assert_equal help_request.creator_uuid, cookies[:creator_uuid]
   end
 
   test "#confirm_security_number with wrong security_number does not redirects to #edit" do
     help_request = help_requests(:monique_request)
-    post help_request_confirm_security_number_path(id: help_request.id), params: {security_number: "invalid number"}
+    post help_request_confirm_security_number_path(uuid: help_request.uuid), params: {security_number: "invalid number"}
     assert_response :ok
     assert_not_equal help_request.creator_uuid, cookies[:creator_uuid]
   end


### PR DESCRIPTION
I dont like the idea that help requests id's are guessable, i dont want people to stalk requests.